### PR TITLE
Fixed bad threads handling

### DIFF
--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -42,9 +42,9 @@ public class TopManager {
         CacheMethod method = plugin.getCache().getMethod();
         int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
         fetchService = new ThreadPoolExecutor(
-                t, t,
-                500, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(1000000, true)
+                1, t,
+                100, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>()
         );
         fetchService.allowCoreThreadTimeOut(true);
         fetchService.setThreadFactory(ThreadFactoryProxy.getDefaultThreadFactory("AJLBFETCH"));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -103,8 +103,8 @@ reset-weekly-on: sunday
 # Lower this if you get the message "unable to create native thread: possibly out of memory or process/resource limits reached"
 # I would __not__ recommend setting this below 20.
 # Requires a server restart to change
-#  Default: 70
-max-fetching-threads: 70
+#  Default: 4
+max-fetching-threads: 4
 
 
 


### PR DESCRIPTION
ajLeaderboards tends to create hundreds of thousands of threads within a span of a few minutes (I am not exaggerating). With virtual threads not existing yet, this is not really something you want to do, as threads were designed to have a long lifetime. My changes increase the duration until a thread gets disposed, and a new one is being created. Additionally, I decreased the max threads count to something more reasonable. The reason why I created this fork is that I got annoyed with the threads filling up my profiler and me noticing that ajLeaderboard consuming more CPU usage than it really should.