### PR TITLE
Fixed exaggerated threads handling

### DIFF
--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -40,9 +40,16 @@ public class TopManager {
     public TopManager(LeaderboardPlugin pl) {
         plugin = pl;
         CacheMethod method = plugin.getCache().getMethod();
-        int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
+
+        int t = plugin.getAConfig().getInt("max-fetching-threads");
+
+        if(method instanceof MysqlMethod)
+            t = Math.min(t, method.getMaxConnections());
+        if(t < 1)
+            t = 1;
+
         fetchService = new ThreadPoolExecutor(
-                1, t,
+                t, t,
                 60, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>()
         );

--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -42,9 +42,9 @@ public class TopManager {
         CacheMethod method = plugin.getCache().getMethod();
         int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
         fetchService = new ThreadPoolExecutor(
-                t, t,
-                500, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(1000000, true)
+                1, t,
+                60, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>()
         );
         fetchService.allowCoreThreadTimeOut(true);
         fetchService.setThreadFactory(ThreadFactoryProxy.getDefaultThreadFactory("AJLBFETCH"));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -103,8 +103,8 @@ reset-weekly-on: sunday
 # Lower this if you get the message "unable to create native thread: possibly out of memory or process/resource limits reached"
 # I would __not__ recommend setting this below 20.
 # Requires a server restart to change
-#  Default: 70
-max-fetching-threads: 70
+#  Default: 4
+max-fetching-threads: 4
 
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -97,11 +97,8 @@ enable-dontupdate-permission: true
 #  Default: sunday
 reset-weekly-on: sunday
 
-# How many threads should ajLeaderboards be allowed to use maxiumum for fetching from the db?
-# Most of the time, the number of threads used will be far less than this.
-# This is ignored on mysql (and maxConnections is used for this instead)
-# Lower this if you get the message "unable to create native thread: possibly out of memory or process/resource limits reached"
-# I would __not__ recommend setting this below 20.
+# How many threads should ajLeaderboards at most use for fetching data from / putting data into the db?
+# It is recommended to leave this config as it is in case you are unsure with what you are doing
 # Requires a server restart to change
 #  Default: 4
 max-fetching-threads: 4


### PR DESCRIPTION

Revision of #4 
ajLeaderboards tends to create hundreds of thousands of threads within a span of a few minutes (I am not exaggerating). With virtual threads not existing yet, this is not really something you want to do, as threads were designed to have a long lifetime. My changes increase the duration until a thread gets disposed, and a new one is being created. Additionally, I decreased the max threads count to something more reasonable. The reason why I created this fork is that I got annoyed with the threads filling up my profiler and me noticing that ajLeaderboard consuming more CPU usage than it really should.

I will test my changes on a server of a person I am working with