### PR TITLE
Refactored CacheMethod and added support for MongoDB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation("junit:junit:4.12")
+    testImplementation("junit:junit:4.13.1")
 
     implementation("io.github.slimjar:slimjar:1.2.7")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
@@ -50,6 +50,7 @@ dependencies {
 
     slim("com.zaxxer:HikariCP:3.4.5")
     slim("com.h2database:h2:2.1.214")
+    slim("org.mongodb:mongodb-driver-sync:4.9.1")
     //implementation("io.prometheus", "simpleclient", "0.9.0")
 }
 
@@ -67,6 +68,7 @@ tasks.withType<ProcessResources> {
 tasks.slimJar {
     relocate("org.h2", "us.ajg0702.leaderboards.libs.h2")
     relocate("com.zaxxer.hikari", "us.ajg0702.leaderboards.libs.hikari")
+    relocate("org.mongodb", "us.ajg0702.leaderboards.libs.mongodb")
 }
 
 tasks.shadowJar {

--- a/src/main/java/us/ajg0702/leaderboards/boards/StatEntry.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/StatEntry.java
@@ -8,7 +8,6 @@ import us.ajg0702.leaderboards.TimeUtils;
 import us.ajg0702.leaderboards.boards.keys.BoardType;
 import us.ajg0702.leaderboards.cache.Cache;
 import us.ajg0702.leaderboards.utils.EasyJsonObject;
-import us.ajg0702.utils.common.Config;
 import us.ajg0702.utils.common.Messages;
 
 import java.text.DecimalFormat;

--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -42,7 +42,7 @@ public class TopManager {
     public TopManager(LeaderboardPlugin pl, List<String> initialBoards) {
         plugin = pl;
         CacheMethod method = plugin.getCache().getMethod();
-        int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
+        int t = method instanceof MysqlMethod ? Math.max(10, ((MysqlMethod) method).getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
         fetchService = new ThreadPoolExecutor(
                 t, t,
                 500, TimeUnit.MILLISECONDS,

--- a/src/main/java/us/ajg0702/leaderboards/cache/Cache.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/Cache.java
@@ -1,69 +1,42 @@
 package us.ajg0702.leaderboards.cache;
 
-import com.google.common.collect.ImmutableMap;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurateException;
 import us.ajg0702.leaderboards.Debug;
 import us.ajg0702.leaderboards.LeaderboardPlugin;
 import us.ajg0702.leaderboards.boards.StatEntry;
 import us.ajg0702.leaderboards.boards.TimedType;
-import us.ajg0702.leaderboards.boards.keys.BoardType;
 import us.ajg0702.leaderboards.cache.helpers.DbRow;
 import us.ajg0702.leaderboards.cache.methods.H2Method;
+import us.ajg0702.leaderboards.cache.methods.MongoDBMethod;
 import us.ajg0702.leaderboards.cache.methods.MysqlMethod;
 import us.ajg0702.leaderboards.cache.methods.SqliteMethod;
 import us.ajg0702.leaderboards.utils.BoardPlayer;
-import us.ajg0702.leaderboards.utils.Partition;
 import us.ajg0702.utils.common.ConfigFile;
 
-import java.sql.*;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
 @SuppressWarnings("FieldCanBeLocal")
 public class Cache {
-	private String q = "'";
-
-	private final String SELECT_POSITION = "select 'id','value','namecache','prefixcache','suffixcache','displaynamecache',"+deltaBuilder()+" from '%s' order by '%s' %s, namecache desc limit 1 offset %d";
-	private final String SELECT_PLAYER = "select 'id','value','namecache','prefixcache','suffixcache','displaynamecache',"+deltaBuilder()+" from '%s' order by '%s' %s, namecache desc";
-	private final String GET_POSITION = "/*%s*/with N as (select *,ROW_NUMBER() OVER (order by '%s' %s) as position from '%s') select 'id','value','namecache','prefixcache','suffixcache','displaynamecache',position,"+deltaBuilder()+" from N where 'id'=?";
-	private final Map<String, String> CREATE_TABLE = ImmutableMap.of(
-			"sqlite", "create table if not exists '%s' (id TEXT PRIMARY KEY, value DECIMAL(20, 2)"+columnBuilder("NUMERIC")+", namecache TEXT, prefixcache TEXT, suffixcache TEXT, displaynamecache TEXT)",
-			"h2", "create table if not exists '%s' ('id' VARCHAR(36) PRIMARY KEY, 'value' DECIMAL(20, 2)"+columnBuilder("BIGINT")+", 'namecache' VARCHAR(16), 'prefixcache' VARCHAR(255), 'suffixcache' VARCHAR(255), 'displaynamecache' VARCHAR(512))",
-			"mysql", "create table if not exists '%s' ('id' VARCHAR(36) PRIMARY KEY, 'value' DECIMAL(20, 2)"+columnBuilder("BIGINT")+", 'namecache' VARCHAR(16), 'prefixcache' TINYTEXT, 'suffixcache' TINYTEXT, 'displaynamecache' VARCHAR(512))"
-	);
-	private final String REMOVE_PLAYER = "delete from '%s' where 'namecache'=?";
-	private final Map<String, String> LIST_TABLES = ImmutableMap.of(
-			"sqlite", "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
-	);
-	private final String DROP_TABLE = "drop table '%s';";
-	private final String INSERT_PLAYER = "insert into '%s' ('id', 'value', 'namecache', 'prefixcache', 'suffixcache', 'displaynamecache'"+tableBuilder()+") values (?, ?, ?, ?, ?, ?"+qBuilder()+")";
-	private final String UPDATE_PLAYER = "update '%s' set 'value'=?, 'namecache'=?, 'prefixcache'=?, 'suffixcache'=?, 'displaynamecache'=?"+updateBuilder()+" where id=?";
-	private final String QUERY_LASTTOTAL = "select '%s' from '%s' where id=?";
-	private final String QUERY_LASTRESET = "select '%s' from '%s' limit 1";
-	private final String QUERY_IDVALUE = "select id,'value' from '%s'";
-	private final String UPDATE_RESET = "update '%s' set '%s'=?, '%s'=?, '%s'=? where id=?";
-	private final String QUERY_ALL = "select * from '%s'";
-	private final String CREATE_TIMESTAMP_INDEX = "create index %s_timestamp on '%s' (%s_timestamp)";
-
-
-
 	public LeaderboardPlugin getPlugin() {
 		return plugin;
 	}
 
 	ConfigFile storageConfig;
 	final LeaderboardPlugin plugin;
-	final CacheMethod method;
 
-	final String tablePrefix;
+	final CacheMethod method;
 
 	List<String> nonExistantBoards = new ArrayList<>();
 
@@ -81,57 +54,44 @@ public class Cache {
 		}
 
 		String methodStr = storageConfig.getString("method");
-		if(methodStr.equalsIgnoreCase("mysql")) {
-			plugin.getLogger().info("Using MySQL for board cache. ("+methodStr+")");
-			method = new MysqlMethod();
-			tablePrefix = storageConfig.getString("table_prefix");
-			q = "`";
-		} else if(methodStr.equalsIgnoreCase("sqlite")) {
-			plugin.getLogger().info("Using SQLite for board cache. ("+methodStr+")");
-			method = new SqliteMethod();
-			tablePrefix = "";
-			q = "'";
+		if (methodStr.equalsIgnoreCase("mysql")) {
+			plugin.getLogger().info("Using MySQL for board cache. (" + methodStr + ")");
+			method = new MysqlMethod(storageConfig);
+		} else if (methodStr.equalsIgnoreCase("sqlite")) {
+			plugin.getLogger().info("Using SQLite for board cache. (" + methodStr + ")");
+			method = new SqliteMethod(storageConfig);
+		} else if (methodStr.equalsIgnoreCase("mongodb")) {
+			plugin.getLogger().info("Using MongoDB for board cache. (" + methodStr + ")");
+			method = new MongoDBMethod(storageConfig);
 		} else {
-			plugin.getLogger().info("Using H2 flatfile for board cache. ("+methodStr+")");
-			method = new H2Method();
-			tablePrefix = "";
-			q = "`";
+			plugin.getLogger().info("Using H2 flatfile for board cache. (" + methodStr + ")");
+			method = new H2Method(storageConfig);
 		}
 		method.init(plugin, storageConfig, this);
+	}
+
+
+	public CacheMethod getMethod() {
+		return method;
 	}
 
 	/**
 	 * Get a stat. It is reccomended you use TopManager#getStat instead of this,
 	 * unless it is of absolute importance that you have the most up-to-date information
+	 *
 	 * @param position The position to get
-	 * @param board The board
+	 * @param board    The board
 	 * @return The StatEntry representing the position of the board
 	 */
 	public StatEntry getStat(int position, String board, TimedType type) {
-		if(!plugin.getTopManager().boardExists(board)) {
-			if(!nonExistantBoards.contains(board)) {
+		if (!plugin.getTopManager().boardExists(board)) {
+			if (!nonExistantBoards.contains(board)) {
 				nonExistantBoards.add(board);
 			}
 			return StatEntry.boardNotFound(plugin, position, board, type);
 		}
-		boolean reverse = plugin.getAConfig().getStringList("reverse-sort").contains(board);
 		try {
-			Connection conn = method.getConnection();
-			String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
-			PreparedStatement ps = conn.prepareStatement(String.format(
-					method.formatStatement(SELECT_POSITION),
-					tablePrefix+board,
-					sortBy,
-					reverse ? "asc" : "desc",
-					position-1
-			));
-
-			ResultSet r = ps.executeQuery();
-
-			StatEntry se = processData(r, sortBy, position, board, type);
-			ps.close();
-			method.close(conn);
-			return se;
+			return method.getStatEntry(position, board, type);
 		} catch(SQLException e) {
 			plugin.getLogger().log(Level.WARNING, "Unable to get stat of player:", e);
 			return StatEntry.error(plugin, position, board, type);
@@ -140,86 +100,14 @@ public class Cache {
 
 	public List<Integer> rolling = new CopyOnWriteArrayList<>();
 
-	private final Map<String, Integer> sortByIndexes = new ConcurrentHashMap<>();
 	public StatEntry getStatEntry(OfflinePlayer player, String board, TimedType type) {
-		long start = System.currentTimeMillis();
 		if(!plugin.getTopManager().boardExists(board)) {
 			if(!nonExistantBoards.contains(board)) {
 				nonExistantBoards.add(board);
 			}
 			return StatEntry.boardNotFound(plugin, -3, board, type);
 		}
-		boolean reverse = plugin.getAConfig().getStringList("reverse-sort").contains(board);
-		StatEntry r = null;
-		try {
-			Connection conn = method.getConnection();
-			String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
-			PreparedStatement ps = conn.prepareStatement(String.format(
-					method.formatStatement(GET_POSITION),
-					board,
-					sortBy,
-					reverse ? "asc" : "desc",
-					tablePrefix+board
-			));
-
-			ps.setString(1, player.getUniqueId().toString());
-
-			ResultSet rs = ps.executeQuery();
-
-			rs.next();
-
-			String uuidraw = null;
-			double value = -1;
-			String name = "-Unknown-";
-			String displayName = name;
-			String prefix = "";
-			String suffix = "";
-			int position = -1;
-			try {
-				uuidraw = rs.getString(1);
-				name = rs.getString(3);
-				prefix = rs.getString(4);
-				suffix = rs.getString(5);
-				displayName = rs.getString(6);
-				position = rs.getInt(7);
-				value = rs.getDouble(sortByIndexes.computeIfAbsent(sortBy,
-						k -> {
-							try {
-								Debug.info("Calculating (statentry) column for "+sortBy);
-								return rs.findColumn(sortBy);
-							} catch (SQLException e) {
-								plugin.getLogger().log(Level.SEVERE, "Error while finding a column for "+sortBy, e);
-								return -1;
-							}
-						}
-				));
-			} catch(SQLException e) {
-				if(
-						!e.getMessage().contains("ResultSet closed") &&
-								!e.getMessage().contains("empty result set") &&
-								!e.getMessage().contains("[2000-")
-				) {
-					throw e;
-				}
-			}
-			if(uuidraw != null) {
-				r = new StatEntry(position, board, prefix, name, displayName, UUID.fromString(uuidraw), suffix, value, type);
-			}
-			rs.close();
-			ps.close();
-			method.close(conn);
-		} catch (SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "Unable to get position/value of player:", e);
-			return StatEntry.error(plugin, -1, board, type);
-		}
-		rolling.add((int) (System.currentTimeMillis()-start));
-		if(rolling.size() > 50) {
-			rolling.remove(0);
-		}
-		if(r == null) {
-			return StatEntry.noData(plugin, -1, board, type);
-		}
-		return r;
+		return method.getStatEntry(player, board, type);
 	}
 
 	public int getBoardSize(String board) {
@@ -230,116 +118,15 @@ public class Cache {
 			return -3;
 		}
 
-		Connection connection = null;
-		ResultSet rs = null;
-
-		int size;
-
-		try {
-			connection = method.getConnection();
-
-			PreparedStatement ps = connection.prepareStatement(String.format(
-					method.formatStatement("select COUNT(1) from '%s'"),
-					tablePrefix+board
-			));
-
-			rs = ps.executeQuery();
-
-			rs.next();
-
-			size = rs.getInt(1);
-
-		} catch (SQLException e) {
-			if(
-					!e.getMessage().contains("ResultSet closed") &&
-							!e.getMessage().contains("empty result set") &&
-							!e.getMessage().contains("[2000-")
-			) {
-				plugin.getLogger().log(Level.WARNING, "Unable to get size of board:", e);
-				return -1;
-			} else {
-				return 0;
-			}
-		} finally {
-			try {
-				if(connection != null) method.close(connection);
-				if(rs != null) rs.close();
-			} catch (SQLException e) {
-				plugin.getLogger().log(Level.WARNING, "Error while closing resources from board size fetch:", e);
-			}
-
-		}
-
-		return size;
+		return method.getBoardSize(board);
 	}
 
 	public boolean createBoard(String name) {
-		try {
-			Connection conn = method.getConnection();
-			PreparedStatement ps = conn.prepareStatement(method.formatStatement(String.format(
-					CREATE_TABLE.get(method.getName()),
-					tablePrefix+name
-			)));
-
-			ps.executeUpdate();
-
-			ps.close();
-
-			for (TimedType type : TimedType.values()) {
-				if(type == TimedType.ALLTIME) continue;
-
-				try {
-					ps = conn.prepareStatement(method.formatStatement(String.format(
-							CREATE_TIMESTAMP_INDEX,
-							type.lowerName(),
-							tablePrefix+name,
-							type.lowerName()
-					)));
-					ps.executeUpdate();
-				} catch(SQLException e) {
-					if(!e.getMessage().contains("already exists") && !e.getMessage().contains("Duplicate key") ) throw e;
-				}
-				ps.close();
-			}
-
-			method.close(conn);
-			plugin.getTopManager().fetchBoards();
-			plugin.getContextLoader().calculatePotentialContexts();
-			nonExistantBoards.remove(name);
-			if(!plugin.getTopManager().boardExists(name)) {
-				plugin.getLogger().warning("Failed to create board: It wasnt created, but there was no error!");
-				return false;
-			}
-			return true;
-		} catch (SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "Unable to create board:", e);
-			if(e.getCause() != null) {
-				plugin.getLogger().log(Level.WARNING, "Cause:", e);
-			}
-			return false;
-		}
+		return method.createBoard(name);
 	}
 
 	public boolean removePlayer(String board, String playerName) {
-
-		try {
-			Connection conn = method.getConnection();
-			PreparedStatement ps = conn.prepareStatement(String.format(
-					method.formatStatement(REMOVE_PLAYER),
-					tablePrefix+board
-			));
-
-			ps.setString(1, playerName);
-
-			ps.executeUpdate();
-
-			ps.close();
-			method.close(conn);
-			return true;
-		} catch (SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "Unable to remove player from board:", e);
-			return false;
-		}
+		return method.removePlayer(board, playerName);
 	}
 
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -348,76 +135,15 @@ public class Cache {
 	}
 
 	public List<String> getBoards() {
-		List<String> o = new ArrayList<>();
-
-		for(String table : getDbTableList()) {
-			if(table.indexOf(tablePrefix) != 0) continue;
-			String name = table.substring(tablePrefix.length());
-			if(name.equals("extras")) continue;
-			o.add(name);
-		}
-
-		return o;
+		return method.getBoards();
 	}
 
 	public List<String> getDbTableList() {
-		List<String> b = new ArrayList<>();
-		try {
-
-			ResultSet r;
-			Connection conn = method.getConnection();
-			Statement statement = conn.createStatement();
-			r = statement.executeQuery(
-					method.formatStatement(
-							LIST_TABLES.getOrDefault(method.getName(), "show tables;")
-					)
-			);
-			while(r.next()) {
-				String e = r.getString(1);
-				if(e.indexOf(tablePrefix) != 0) continue;
-				String name = e.substring(tablePrefix.length());
-				if(name.equals("extras")) continue;
-				b.add(e);
-			}
-
-			statement.close();
-			r.close();
-			method.close(conn);
-		} catch(SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "Unable to get list of tables:", e);
-		}
-		return b;
+		return method.getDbTableList();
 	}
 
 	public boolean removeBoard(String board) {
-		if(!plugin.getTopManager().boardExists(board)) {
-			plugin.getLogger().warning("Attempted to remove board that doesnt exist!");
-			return false;
-		}
-		try {
-			if(method instanceof SqliteMethod) {
-				((SqliteMethod) method).newConnection();
-			}
-			Connection conn = method.getConnection();
-			PreparedStatement ps = conn.prepareStatement(String.format(
-					method.formatStatement(DROP_TABLE),
-					tablePrefix+board
-			));
-			ps.executeUpdate();
-
-			ps.close();
-			method.close(conn);
-			plugin.getTopManager().fetchBoards();
-			plugin.getContextLoader().calculatePotentialContexts();
-			if(plugin.getTopManager().boardExists(board)) {
-				plugin.getLogger().warning("Attempted to remove a board, but it didnt get removed!");
-				return false;
-			}
-			return true;
-		} catch (SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "An error occurred while trying to remove a board:", e);
-			return false;
-		}
+		return method.removeBoard(board);
 	}
 
 	public void updatePlayerStats(OfflinePlayer player) {
@@ -520,151 +246,11 @@ public class Cache {
 			}
 		}
 
-		Map<TimedType, Double> lastTotals = new HashMap<>();
-		for(TimedType type : TimedType.values()) {
-			if(type == TimedType.ALLTIME) continue;
-			lastTotals.put(type, getLastTotal(board, player, type));
-		}
-
-
-		if(debug) Debug.info("Updating "+player.getName()+" on board "+board+" with values v: "+output+" suffix: "+suffix+" prefix: "+prefix);
-		try(Connection conn = method.getConnection()) {
-			try {
-				PreparedStatement statement = conn.prepareStatement(String.format(
-						method.formatStatement(INSERT_PLAYER),
-						tablePrefix+board
-				));
-				if(debug) Debug.info("in try");
-				statement.setString(1, player.getUniqueId().toString());
-				statement.setDouble(2, output);
-				statement.setString(3, player.getName());
-				statement.setString(4, prefix);
-				statement.setString(5, suffix);
-				statement.setString(6, displayName);
-				int i = 6;
-				for(TimedType type : TimedType.values()) {
-					if(type == TimedType.ALLTIME) continue;
-					long lastReset = plugin.getTopManager().getLastReset(board, type)*1000;
-					if(plugin.isShuttingDown()) {
-						method.close(conn);
-					}
-					statement.setDouble(++i, 0);
-					statement.setDouble(++i, output);
-					statement.setLong(++i, lastReset == 0 ? System.currentTimeMillis() : lastReset);
-				}
-
-				statement.executeUpdate();
-				statement.close();
-				method.close(conn);
-			} catch(SQLException e) {
-				if(debug) Debug.info("in catch: " + e.getMessage());
-				try(PreparedStatement statement = conn.prepareStatement(String.format(
-						method.formatStatement(UPDATE_PLAYER),
-						tablePrefix+board
-				))) {
-					statement.setDouble(1, output);
-					statement.setString(2, player.getName());
-					statement.setString(3, prefix);
-					statement.setString(4, suffix);
-					statement.setString(5, displayName);
-					Map<TimedType, Double> timedTypeValues = new HashMap<>();
-					timedTypeValues.put(TimedType.ALLTIME, output);
-					int i = 6;
-					for(TimedType type : TimedType.values()) {
-						if(type == TimedType.ALLTIME) continue;
-						double timedOut = output-lastTotals.get(type);
-						timedTypeValues.put(type, timedOut);
-						statement.setDouble(i++, timedOut);
-					}
-					for (Map.Entry<TimedType, Double> timedTypeDoubleEntry : timedTypeValues.entrySet()) {
-						TimedType type = timedTypeDoubleEntry.getKey();
-						double timedOut = timedTypeDoubleEntry.getValue();
-
-						StatEntry statEntry = plugin.getTopManager().getCachedStatEntry(player, board, type, false);
-						if(statEntry != null && player.getUniqueId().equals(statEntry.getPlayerID())) {
-							statEntry.changeScore(timedOut, prefix, suffix);
-						}
-
-						Integer position = plugin.getTopManager()
-								.positionPlayerCache.getOrDefault(player.getUniqueId(), new HashMap<>())
-								.get(new BoardType(board, type));
-						if(position != null) {
-							StatEntry stat = plugin.getTopManager().getCachedStat(position, board, type);
-							if(stat != null && player.getUniqueId().equals(stat.getPlayerID())) {
-								stat.changeScore(timedOut, prefix, suffix);
-							}
-						}
-					}
-					statement.setString(i, player.getUniqueId().toString());
-					statement.executeUpdate();
-				}
-			}
-		} catch(SQLException e) {
-			if(plugin.isShuttingDown()) return;
-			plugin.getLogger().log(Level.WARNING, "Unable to update stat for player:", e);
-		}
-	}
-
-	public double getLastTotal(String board, OfflinePlayer player, TimedType type) {
-		double last = 0;
-		try {
-			Connection conn = method.getConnection();
-			try {
-				PreparedStatement ps = conn.prepareStatement(String.format(
-						method.formatStatement(QUERY_LASTTOTAL),
-						type.lowerName()+"_lasttotal",
-						tablePrefix+board
-				));
-
-				ps.setString(1, player.getUniqueId().toString());
-
-				ResultSet rs = ps.executeQuery();
-
-				if(method instanceof MysqlMethod || method instanceof H2Method) {
-					rs.next();
-				}
-				last = rs.getDouble(1);
-				rs.close();
-				ps.close();
-				method.close(conn);
-			} catch(SQLException e) {
-				method.close(conn);
-				String m = e.getMessage();
-				if(m.contains("empty result set") || m.contains("ResultSet closed") || m.contains("[2000-")) return last;
-				plugin.getLogger().log(Level.WARNING, "Unable to get last total for "+player.getName()+" on "+type+" of "+board, e);
-			}
-		} catch(SQLException ignored) {}
-
-		return last;
+		method.upsertPlayer(board, player, output, displayName, prefix, suffix);
 	}
 
 	public long getLastReset(String board, TimedType type) {
-		long last = 0;
-		try {
-			Connection conn = method.getConnection();
-			try {
-				PreparedStatement ps = conn.prepareStatement(String.format(
-						method.formatStatement(QUERY_LASTRESET),
-						type.lowerName()+"_timestamp",
-						tablePrefix+board
-				));
-
-				ResultSet rs = ps.executeQuery();
-				if(method instanceof MysqlMethod || method instanceof H2Method) {
-					rs.next();
-				}
-				last = rs.getLong(1);
-				ps.close();
-				method.close(conn);
-			} catch(SQLException e) {
-				method.close(conn);
-				String m = e.getMessage();
-				if(m.contains("empty result set") || m.contains("ResultSet closed") || m.contains("[2000-")) return last;
-				plugin.getLogger().log(Level.WARNING, "Unable to get last reset for "+type+" of "+board, e);
-			}
-		} catch(SQLException ignored) {}
-
-		return last;
+		return method.getLastReset(board, type);
 	}
 
 	public void reset(String board, TimedType type) throws ExecutionException, InterruptedException {
@@ -677,132 +263,27 @@ public class Cache {
 
 		long startTime = System.currentTimeMillis();
 		LocalDateTime startDateTime = LocalDateTime.now();
-		long newTime = startDateTime.atOffset(ZoneOffset.UTC).toEpochSecond()*1000;
-		Debug.info(board+" "+type+" "+startDateTime.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.RFC_1123_DATE_TIME)+" "+newTime);
-		if(type.equals(TimedType.ALLTIME)) {
+		long newTime = startDateTime.atOffset(ZoneOffset.UTC).toEpochSecond() * 1000;
+		Debug.info(board + " " + type + " " + startDateTime.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.RFC_1123_DATE_TIME) + " " + newTime);
+		if (type.equals(TimedType.ALLTIME)) {
 			throw new IllegalArgumentException("Cannot reset ALLTIME!");
 		}
-		Debug.info("Resetting "+board+" "+type.lowerName()+" leaderboard");
-		long lastReset = plugin.getTopManager().getLastReset(board, type)*1000L;
-		if(plugin.isShuttingDown()) {
+		Debug.info("Resetting " + board + " " + type.lowerName() + " leaderboard");
+		long lastReset = plugin.getTopManager().getLastReset(board, type) * 1000L;
+		if (plugin.isShuttingDown()) {
 			return;
 		}
-		Debug.info("last: "+lastReset+" gap: "+(startTime - lastReset));
-		String t = type.lowerName();
-		try {
-			Connection conn = method.getConnection();
-			PreparedStatement ps = conn.prepareStatement(String.format(
-					method.formatStatement(QUERY_IDVALUE),
-					tablePrefix+board
-			));
-
-			ResultSet rs = ps.executeQuery();
-			Map<String, Double> uuids = new HashMap<>();
-			while(rs.next()) {
-				uuids.put(rs.getString(1), rs.getDouble(2));
-			}
-			rs.close();
-			ps.close();
-			method.close(conn);
-			Partition<String> partition = Partition.ofSize(new ArrayList<>(uuids.keySet()), Math.max(uuids.size()/(int) Math.ceil(method.getMaxConnections()/2D), 1));
-			Debug.info("Partition length: "+partition.size()+" uuids size: "+ uuids.size()+" partition chunk size: "+partition.getChunkSize());
-			for(List<String> uuidPartition : partition) {
-				if(plugin.isShuttingDown()) {
-					method.close(conn);
-					return;
-				}
-				try {
-					Connection con = method.getConnection();
-					for(String idRaw : uuidPartition) {
-						if(plugin.isShuttingDown()) {
-							method.close(con);
-							return;
-						}
-						PreparedStatement p = con.prepareStatement(String.format(
-								method.formatStatement(UPDATE_RESET),
-								tablePrefix+board,
-								t+"_lasttotal",
-								t+"_delta",
-								t+"_timestamp"
-						));
-						p.setDouble(1, uuids.get(idRaw));
-						p.setDouble(2, 0);
-						p.setLong(3, newTime);
-						p.setString(4, idRaw);
-						p.executeUpdate();
-						p.close();
-					}
-					method.close(con);
-				} catch (SQLException e) {
-					plugin.getLogger().log(Level.WARNING, "An error occurred while resetting "+type+" of "+board+":", e);
-				}
-			}
-		} catch (SQLException e) {
-			plugin.getLogger().log(Level.WARNING, "An error occurred while resetting "+type+" of "+board+":", e);
-		}
-		Debug.info("Reset of "+board+" "+type.lowerName()+" took "+(System.currentTimeMillis()-startTime)+"ms");
+		Debug.info("last: " + lastReset + " gap: " + (startTime - lastReset));
+		method.resetBoard(board, type, newTime);
+		Debug.info("Reset of " + board + " " + type.lowerName() + " took " + (System.currentTimeMillis()-startTime)+"ms");
 	}
 
 	public void insertRows(String board, List<DbRow> rows) throws SQLException {
-		Connection conn = method.getConnection();
-		for(DbRow row : rows) {
-			PreparedStatement statement = conn.prepareStatement(String.format(
-					method.formatStatement(INSERT_PLAYER),
-					tablePrefix+board
-			));
-			statement.setString(1, row.getId().toString());
-			statement.setDouble(2, row.getValue());
-			statement.setString(3, row.getNamecache());
-			statement.setString(4, row.getPrefixcache());
-			statement.setString(5, row.getSuffixcache());
-			statement.setString(6, row.getDisplaynamecache());
-			int i = 6;
-			for(TimedType type : TimedType.values()) {
-				if(type == TimedType.ALLTIME) continue;
-				if(plugin.isShuttingDown()) {
-					method.close(conn);
-				}
-				statement.setDouble(++i, row.getDeltas().get(type));
-				statement.setDouble(++i, row.getLastTotals().get(type));
-				statement.setLong(++i, row.getTimestamps().get(type));
-			}
-
-			try {
-				statement.executeUpdate();
-			} catch(SQLException e) {
-				if(e.getMessage().contains("23505") || e.getMessage().contains("Duplicate entry") || e.getMessage().contains("PRIMARY KEY constraint failed")) {
-					statement.close();
-					continue;
-				}
-				throw e;
-			}
-			statement.close();
-		}
-		method.close(conn);
+		method.insertRows(board, rows);
 	}
 
 	public List<DbRow> getRows(String board) throws SQLException {
-		Connection conn = method.getConnection();
-		PreparedStatement ps = conn.prepareStatement(String.format(
-				method.formatStatement(QUERY_ALL),
-				tablePrefix+board
-		));
-		ResultSet resultSet = ps.executeQuery();
-
-		List<DbRow> out = new ArrayList<>();
-
-		while(resultSet.next()) {
-			out.add(new DbRow(resultSet));
-		}
-
-		ps.close();
-		resultSet.close();
-		method.close(conn);
-		return out;
-	}
-
-	public CacheMethod getMethod() {
-		return method;
+		return method.getRows(board);
 	}
 
 	private static final HashMap<String, String> altPlaceholders = new HashMap<String, String>() {{
@@ -813,109 +294,6 @@ public class Cache {
 	}};
 	public static String alternatePlaceholders(String board) {
 		return altPlaceholders.getOrDefault(board, board);
-	}
-
-	public String getTablePrefix() {
-		return tablePrefix;
-	}
-
-	private String deltaBuilder() {
-		StringBuilder deltaBuilder = new StringBuilder();
-		for(TimedType t : TimedType.values()) {
-			if(t == TimedType.ALLTIME) continue;
-			deltaBuilder.append(q).append(t.lowerName()).append("_delta").append(q).append(",");
-		}
-		return deltaBuilder.deleteCharAt(deltaBuilder.length()-1).toString();
-	}
-	private String columnBuilder(String t) {
-		String q = "'";
-		StringBuilder columns = new StringBuilder();
-		for(TimedType type : TimedType.values()) {
-			if(type == TimedType.ALLTIME) continue;
-			columns
-					.append(",\n").append(q).append(type.lowerName()).append("_delta").append(q).append(" ").append(t)
-					.append(",\n").append(q).append(type.lowerName()).append("_lasttotal").append(q).append(" ").append(t)
-					.append(",\n").append(q).append(type.lowerName()).append("_timestamp").append(q).append(" ").append(t);
-		}
-		return columns.toString();
-	}
-	private String qBuilder() {
-		StringBuilder addQs = new StringBuilder();
-		for(TimedType type : TimedType.values()) {
-			if(type == TimedType.ALLTIME) continue;
-			addQs.append(", ?").append(", ?").append(", ?");
-		}
-		return addQs.toString();
-	}
-
-	private String tableBuilder() {
-		StringBuilder addTables = new StringBuilder();
-		for(TimedType type : TimedType.values()) {
-			if(type == TimedType.ALLTIME) continue;
-			String name = type.lowerName();
-			addTables
-					.append(", ").append(name).append("_delta")
-					.append(", ").append(name).append("_lasttotal")
-					.append(", ").append(name).append("_timestamp");
-		}
-		return addTables.toString();
-	}
-
-	private String updateBuilder() {
-		StringBuilder addUpdates = new StringBuilder();
-		for(TimedType type : TimedType.values()) {
-			if(type == TimedType.ALLTIME) continue;
-			String name = type.lowerName();
-			addUpdates
-					.append(", ").append(name).append("_delta").append("=?");
-		}
-		return addUpdates.toString();
-	}
-
-	Map<String, Integer> dataSortByIndexes = new ConcurrentHashMap<>();
-	private StatEntry processData(ResultSet r, String sortBy, int position, String board, TimedType type) throws SQLException {
-		String uuidRaw = null;
-		double value = -1;
-		String name = "-Unknown-";
-		String displayName = name;
-		String prefix = "";
-		String suffix = "";
-		if(method instanceof MysqlMethod || method instanceof H2Method) {
-			r.next();
-		}
-		try {
-			uuidRaw = r.getString(1);
-			name = r.getString(3);
-			prefix = r.getString(4);
-			suffix = r.getString(5);
-			displayName = r.getString(6);
-			value = r.getDouble(dataSortByIndexes.computeIfAbsent(sortBy,
-					k -> {
-						try {
-							Debug.info("Calculating (process) column for "+sortBy);
-							return r.findColumn(sortBy);
-						} catch (SQLException e) {
-							plugin.getLogger().log(Level.SEVERE, "Error while finding a column for "+sortBy, e);
-							return -1;
-						}
-					}
-			));
-		} catch(SQLException e) {
-			if(
-					!e.getMessage().contains("ResultSet closed") &&
-							!e.getMessage().contains("empty result set") &&
-							!e.getMessage().contains("[2000-")
-			) {
-				throw e;
-			}
-		}
-		if(name == null) name = "-Unknown";
-		r.close();
-		if(uuidRaw == null) {
-			return StatEntry.noData(plugin, position, board, type);
-		} else {
-			return new StatEntry(position, board, prefix, name, displayName, UUID.fromString(uuidRaw), suffix, value, type);
-		}
 	}
 
 	/**

--- a/src/main/java/us/ajg0702/leaderboards/cache/CacheMethod.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/CacheMethod.java
@@ -1,18 +1,58 @@
 package us.ajg0702.leaderboards.cache;
 
+import org.bukkit.OfflinePlayer;
 import us.ajg0702.leaderboards.LeaderboardPlugin;
+import us.ajg0702.leaderboards.boards.StatEntry;
+import us.ajg0702.leaderboards.boards.TimedType;
+import us.ajg0702.leaderboards.cache.helpers.DbRow;
 import us.ajg0702.utils.common.ConfigFile;
 
-import java.sql.Connection;
+import javax.annotation.Nullable;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
 
 public interface CacheMethod {
-    Connection getConnection() throws SQLException;
     void init(LeaderboardPlugin plugin, ConfigFile config, Cache cacheInstance);
-    void close(Connection connection) throws SQLException;
-    int getMaxConnections();
+
     void shutdown();
-    String formatStatement(String s);
+
     String getName();
+
     boolean requiresClose();
+
+    StatEntry getStatEntry(int position, String board, TimedType type) throws SQLException;
+
+    @Nullable
+    StatEntry getStatEntry(OfflinePlayer player, String board, TimedType type);
+
+    int getBoardSize(String board);
+
+    double getLastTotal(String board, OfflinePlayer player, TimedType type);
+
+    long getLastReset(String board, TimedType type);
+
+    void resetBoard(String board, TimedType type, long newTime);
+
+    void insertRows(String board, List<DbRow> rows) throws SQLException;
+
+    List<DbRow> getRows(String board) throws SQLException;
+
+    boolean createBoard(String name);
+
+    boolean removePlayer(String board, String playerName);
+
+    void upsertPlayer(String board, OfflinePlayer player, double output, String prefix, String suffix, String displayName);
+
+    boolean removeBoard(String board);
+
+    List<String> getDbTableList();
+
+    List<String> getBoards();
+
+    String getExtra(UUID id, String placeholder);
+
+    void upsertExtra(UUID id, String placeholder, String value);
+
+    void createExtraTable();
 }

--- a/src/main/java/us/ajg0702/leaderboards/cache/ExtraManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/ExtraManager.java
@@ -1,36 +1,17 @@
 package us.ajg0702.leaderboards.cache;
 
-import com.google.common.collect.ImmutableMap;
-import us.ajg0702.leaderboards.Debug;
 import us.ajg0702.leaderboards.LeaderboardPlugin;
-import us.ajg0702.leaderboards.boards.StatEntry;
-import us.ajg0702.leaderboards.cache.methods.H2Method;
-import us.ajg0702.leaderboards.cache.methods.MysqlMethod;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.logging.Level;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import java.util.regex.Matcher;
 
 @SuppressWarnings("FieldCanBeLocal")
 public class ExtraManager {
     private final LeaderboardPlugin plugin;
     private final Cache cache;
-
-    private final Map<String, String> CREATE_TABLE = ImmutableMap.of(
-            "sqlite", "create table if not exists '%s' (id TEXT, placeholder VARCHAR(255), value VARCHAR(255))",
-            "h2", "create table if not exists '%s' ('id' VARCHAR(36), 'placeholder' VARCHAR(255), 'value' VARCHAR(255))",
-            "mysql", "create table if not exists '%s' ('id' VARCHAR(36), 'placeholder' VARCHAR(255), 'value' VARCHAR(255))"
-    );
-    private final String QUERY_IDVALUE = "select id,'value' from '%s' where id=? and 'placeholder'=?";
-    private final String INSERT_PLAYER = "insert into '%s' ('id', 'placeholder', 'value') values (?, ?, ?)";
-    private final String UPDATE_PLAYER = "update '%s' set 'value'=? where id=? and 'placeholder'=?";
-
     private final CacheMethod method;
-    private final String tableName;
 
     public ExtraManager(LeaderboardPlugin plugin) {
         this.plugin = plugin;
@@ -40,62 +21,11 @@ public class ExtraManager {
             throw new IllegalStateException("Cache not found. Has it been loaded?");
         }
         this.method = cache.getMethod();
-        tableName = cache.getTablePrefix()+"extras";
-
-        try {
-            Connection conn = method.getConnection();
-            PreparedStatement ps = conn.prepareStatement(method.formatStatement(String.format(
-                    Objects.requireNonNull(CREATE_TABLE.get(method.getName())),
-                    tableName
-            )));
-
-            ps.executeUpdate();
-
-            ps.close();
-            method.close(conn);
-        } catch(SQLException e) {
-            plugin.getLogger().log(Level.SEVERE, "Failed to create storage for Extras:", e);
-        }
+        this.method.createExtraTable();
     }
 
     public String getExtra(UUID id, String placeholder) {
-        try {
-            Connection conn = method.getConnection();
-            PreparedStatement ps = conn.prepareStatement(method.formatStatement(String.format(
-                    Objects.requireNonNull(QUERY_IDVALUE),
-                    tableName
-            )));
-
-            ps.setString(1, id.toString());
-            ps.setString(2, placeholder);
-
-            ResultSet rs = ps.executeQuery();
-
-            if(method instanceof MysqlMethod || method instanceof H2Method) {
-                rs.next();
-            }
-
-            String value = null;
-            try {
-                value = rs.getString(2);
-            } catch(SQLException e) {
-                if(
-                        !e.getMessage().contains("ResultSet closed") &&
-                                !e.getMessage().contains("empty result set") &&
-                                !e.getMessage().contains("[2000-")
-                ) {
-                    throw e;
-                }
-            }
-
-            rs.close();
-            ps.close();
-            method.close(conn);
-            return value;
-        } catch (SQLException e) {
-            plugin.getLogger().log(Level.WARNING, "An error occurred while fetching an extra:", e);
-            return StatEntry.AN_ERROR_OCCURRED;
-        }
+        return method.getExtra(id, placeholder);
     }
 
     public List<String> getExtras() {
@@ -109,36 +39,7 @@ public class ExtraManager {
 
     public void setExtra(UUID id, String placeholder, String value) {
         if(plugin.isShuttingDown()) return;
-        try {
-            Connection conn = method.getConnection();
-
-            PreparedStatement statement = conn.prepareStatement(String.format(
-                    method.formatStatement(UPDATE_PLAYER),
-                    tableName
-            ));
-            statement.setString(1, value);
-            statement.setString(2, id.toString());
-            statement.setString(3, placeholder);
-
-            int rowsChanged = statement.executeUpdate();
-            statement.close();
-            if(rowsChanged == 0) {
-                PreparedStatement insertStmt = conn.prepareStatement(String.format(
-                        method.formatStatement(INSERT_PLAYER),
-                        tableName
-                ));
-
-                insertStmt.setString(1, id.toString());
-                insertStmt.setString(2, placeholder);
-                insertStmt.setString(3, value);
-
-                insertStmt.executeUpdate();
-                insertStmt.close();
-            }
-            method.close(conn);
-        } catch(SQLException e) {
-            plugin.getLogger().log(Level.WARNING, "An error occurred while inserting an extra:", e);
-        }
+        method.upsertExtra(id, placeholder, value);
     }
 
 }

--- a/src/main/java/us/ajg0702/leaderboards/cache/SQLCacheMethod.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/SQLCacheMethod.java
@@ -1,0 +1,821 @@
+package us.ajg0702.leaderboards.cache;
+
+import com.google.common.collect.ImmutableMap;
+import org.bukkit.OfflinePlayer;
+import us.ajg0702.leaderboards.Debug;
+import us.ajg0702.leaderboards.LeaderboardPlugin;
+import us.ajg0702.leaderboards.boards.StatEntry;
+import us.ajg0702.leaderboards.boards.TimedType;
+import us.ajg0702.leaderboards.boards.keys.BoardType;
+import us.ajg0702.leaderboards.cache.helpers.DbRow;
+import us.ajg0702.leaderboards.cache.methods.H2Method;
+import us.ajg0702.leaderboards.cache.methods.MysqlMethod;
+import us.ajg0702.leaderboards.cache.methods.SqliteMethod;
+import us.ajg0702.leaderboards.utils.Partition;
+import us.ajg0702.utils.common.ConfigFile;
+
+import javax.annotation.Nullable;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+public abstract class SQLCacheMethod implements CacheMethod {
+    final ConfigFile storageConfig;
+    private final String SELECT_POSITION = "select 'id','value','namecache','prefixcache','suffixcache','displaynamecache'," + deltaBuilder() + " from '%s' order by '%s' %s, namecache desc limit 1 offset %d";
+    private final String GET_POSITION = "/*%s*/with N as (select *,ROW_NUMBER() OVER (order by '%s' %s) as position from '%s') select 'id','value','namecache','prefixcache','suffixcache','displaynamecache',position," + deltaBuilder() + " from N where 'id'=?";
+    private final Map<String, String> CREATE_TABLE = ImmutableMap.of(
+            "sqlite", "create table if not exists '%s' (id TEXT PRIMARY KEY, value DECIMAL(20, 2)" + columnBuilder("NUMERIC") + ", namecache TEXT, prefixcache TEXT, suffixcache TEXT, displaynamecache TEXT)",
+            "h2", "create table if not exists '%s' ('id' VARCHAR(36) PRIMARY KEY, 'value' DECIMAL(20, 2)" + columnBuilder("BIGINT") + ", 'namecache' VARCHAR(16), 'prefixcache' VARCHAR(255), 'suffixcache' VARCHAR(255), 'displaynamecache' VARCHAR(512))",
+            "mysql", "create table if not exists '%s' ('id' VARCHAR(36) PRIMARY KEY, 'value' DECIMAL(20, 2)" + columnBuilder("BIGINT") + ", 'namecache' VARCHAR(16), 'prefixcache' TINYTEXT, 'suffixcache' TINYTEXT, 'displaynamecache' VARCHAR(512))"
+    );
+    private final Map<String, String> CREATE_EXTRA_TABLE = ImmutableMap.of(
+            "sqlite", "create table if not exists '%s' (id TEXT, placeholder VARCHAR(255), value VARCHAR(255))",
+            "h2", "create table if not exists '%s' ('id' VARCHAR(36), 'placeholder' VARCHAR(255), 'value' VARCHAR(255))",
+            "mysql", "create table if not exists '%s' ('id' VARCHAR(36), 'placeholder' VARCHAR(255), 'value' VARCHAR(255))"
+    );
+    private final String REMOVE_PLAYER = "delete from '%s' where 'namecache'=?";
+    private final Map<String, String> LIST_TABLES = ImmutableMap.of(
+            "sqlite", "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
+    );
+    private final String DROP_TABLE = "drop table '%s';";
+    private final String INSERT_PLAYER = "insert into '%s' ('id', 'value', 'namecache', 'prefixcache', 'suffixcache', 'displaynamecache'" + tableBuilder() + ") values (?, ?, ?, ?, ?, ?" + qBuilder() + ")";
+    private final String UPDATE_PLAYER = "update '%s' set 'value'=?, 'namecache'=?, 'prefixcache'=?, 'suffixcache'=?, 'displaynamecache'=?" + updateBuilder() + " where id=?";
+    private final String INSERT_PLAYER_EXTRA = "insert into '%s' ('id', 'placeholder', 'value') values (?, ?, ?)";
+    private final String UPDATE_PLAYER_EXTRA = "update '%s' set 'value'=? where id=? and 'placeholder'=?";
+    private final String QUERY_IDVALUE_EXTRA = "select id,'value' from '%s' where id=? and 'placeholder'=?";
+    private final String QUERY_LASTTOTAL = "select '%s' from '%s' where id=?";
+    private final String QUERY_LASTRESET = "select '%s' from '%s' limit 1";
+    private final String QUERY_IDVALUE = "select id,'value' from '%s'";
+    private final String UPDATE_RESET = "update '%s' set '%s'=?, '%s'=?, '%s'=? where id=?";
+    private final String QUERY_ALL = "select * from '%s'";
+    private final String CREATE_TIMESTAMP_INDEX = "create index %s_timestamp on '%s' (%s_timestamp)";
+    private final Map<String, Integer> sortByIndexes = new ConcurrentHashMap<>();
+    Map<String, Integer> dataSortByIndexes = new ConcurrentHashMap<>();
+    List<String> nonExistantBoards = new ArrayList<>();
+
+    protected SQLCacheMethod(ConfigFile storageConfig) {
+        this.storageConfig = storageConfig;
+    }
+
+    abstract public Connection getConnection() throws SQLException;
+
+    abstract public int getMaxConnections();
+
+    abstract public String formatStatement(String s);
+
+    abstract public String getQuotationMark();
+
+    abstract public String getTablePrefix();
+
+    abstract public void close(Connection connection) throws SQLException;
+
+    protected abstract LeaderboardPlugin getPlugin();
+
+    @Override
+    public StatEntry getStatEntry(int position, String board, TimedType type) throws SQLException {
+        Connection conn = this.getConnection();
+        String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
+        PreparedStatement ps = conn.prepareStatement(String.format(
+                this.formatStatement(SELECT_POSITION),
+                getTablePrefix() + board,
+                sortBy,
+                isReverse(board) ? "asc" : "desc",
+                position - 1
+        ));
+
+        ResultSet r = ps.executeQuery();
+
+        StatEntry se = processData(r, sortBy, position, board, type);
+        ps.close();
+        this.close(conn);
+        return se;
+    }
+
+    @Override
+    @Nullable
+    public StatEntry getStatEntry(OfflinePlayer player, String board, TimedType type) {
+        StatEntry r = null;
+        try {
+            Connection conn = this.getConnection();
+            String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
+            PreparedStatement ps = conn.prepareStatement(String.format(
+                    this.formatStatement(GET_POSITION),
+                    board,
+                    sortBy,
+                    isReverse(board) ? "asc" : "desc",
+                    getTablePrefix() + board
+            ));
+
+            ps.setString(1, player.getUniqueId().toString());
+
+            ResultSet rs = ps.executeQuery();
+
+            rs.next();
+
+            String uuidraw = null;
+            double value = -1;
+            String name = "-Unknown-";
+            String displayName = name;
+            String prefix = "";
+            String suffix = "";
+            int position = -1;
+            try {
+                uuidraw = rs.getString(1);
+                name = rs.getString(3);
+                prefix = rs.getString(4);
+                suffix = rs.getString(5);
+                displayName = rs.getString(6);
+                position = rs.getInt(7);
+                value = rs.getDouble(sortByIndexes.computeIfAbsent(sortBy,
+                        k -> {
+                            try {
+                                Debug.info("Calculating (statentry) column for " + sortBy);
+                                return rs.findColumn(sortBy);
+                            } catch (SQLException e) {
+                                getPlugin().getLogger().log(Level.SEVERE, "Error while finding a column for " + sortBy, e);
+                                return -1;
+                            }
+                        }
+                ));
+            } catch (SQLException e) {
+                if (
+                        !e.getMessage().contains("ResultSet closed") &&
+                                !e.getMessage().contains("empty result set") &&
+                                !e.getMessage().contains("[2000-")
+                ) {
+                    throw e;
+                }
+            }
+            if (uuidraw != null) {
+                r = new StatEntry(position, board, prefix, name, displayName, UUID.fromString(uuidraw), suffix, value, type);
+            }
+            rs.close();
+            ps.close();
+            this.close(conn);
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "Unable to get position/value of player:", e);
+            return StatEntry.error(getPlugin(), -1, board, type);
+        }
+        return r;
+    }
+
+    @Override
+    public int getBoardSize(String board) {
+        Connection connection = null;
+        ResultSet rs = null;
+
+        int size;
+
+        try {
+            connection = this.getConnection();
+
+            PreparedStatement ps = connection.prepareStatement(String.format(
+                    this.formatStatement("select COUNT(1) from '%s'"),
+                    getTablePrefix() + board
+            ));
+
+            rs = ps.executeQuery();
+
+            rs.next();
+
+            size = rs.getInt(1);
+
+        } catch (SQLException e) {
+            if (
+                    !e.getMessage().contains("ResultSet closed") &&
+                            !e.getMessage().contains("empty result set") &&
+                            !e.getMessage().contains("[2000-")
+            ) {
+                getPlugin().getLogger().log(Level.WARNING, "Unable to get size of board:", e);
+                return -1;
+            } else {
+                return 0;
+            }
+        } finally {
+            try {
+                if (connection != null) this.close(connection);
+                if (rs != null) rs.close();
+            } catch (SQLException e) {
+                getPlugin().getLogger().log(Level.WARNING, "Error while closing resources from board size fetch:", e);
+            }
+
+        }
+
+        return size;
+    }
+
+    @Override
+    public boolean createBoard(String name) {
+        try {
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(this.formatStatement(String.format(
+                    CREATE_TABLE.get(this.getName()),
+                    getTablePrefix() + name
+            )));
+
+            ps.executeUpdate();
+
+            ps.close();
+
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+
+                try {
+                    ps = conn.prepareStatement(this.formatStatement(String.format(
+                            CREATE_TIMESTAMP_INDEX,
+                            type.lowerName(),
+                            getTablePrefix() + name,
+                            type.lowerName()
+                    )));
+                    ps.executeUpdate();
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("already exists") && !e.getMessage().contains("Duplicate key"))
+                        throw e;
+                }
+                ps.close();
+            }
+
+            this.close(conn);
+            getPlugin().getTopManager().fetchBoards();
+            getPlugin().getContextLoader().calculatePotentialContexts();
+            nonExistantBoards.remove(name);
+            if (!getPlugin().getTopManager().boardExists(name)) {
+                getPlugin().getLogger().warning("Failed to create board: It wasnt created, but there was no error!");
+                return false;
+            }
+            return true;
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "Unable to create board:", e);
+            if (e.getCause() != null) {
+                getPlugin().getLogger().log(Level.WARNING, "Cause:", e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removePlayer(String board, String playerName) {
+        try {
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(String.format(
+                    this.formatStatement(REMOVE_PLAYER),
+                    getTablePrefix() + board
+            ));
+
+            ps.setString(1, playerName);
+
+            ps.executeUpdate();
+
+            ps.close();
+            this.close(conn);
+            return true;
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "Unable to remove player from board:", e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<String> getBoards() {
+        List<String> o = new ArrayList<>();
+
+        for (String table : getDbTableList()) {
+            if (table.indexOf(getTablePrefix()) != 0) continue;
+            String name = table.substring(getTablePrefix().length());
+            if (name.equals("extras")) continue;
+            o.add(name);
+        }
+
+        return o;
+    }
+
+    @Override
+    public List<String> getDbTableList() {
+        List<String> b = new ArrayList<>();
+        try {
+
+            ResultSet r;
+            Connection conn = this.getConnection();
+            Statement statement = conn.createStatement();
+            r = statement.executeQuery(
+                    this.formatStatement(
+                            LIST_TABLES.getOrDefault(this.getName(), "show tables;")
+                    )
+            );
+            while (r.next()) {
+                String e = r.getString(1);
+                if (e.indexOf(getTablePrefix()) != 0) continue;
+                String name = e.substring(getTablePrefix().length());
+                if (name.equals("extras")) continue;
+                b.add(e);
+            }
+
+            statement.close();
+            r.close();
+            this.close(conn);
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "Unable to get list of tables:", e);
+        }
+        return b;
+    }
+
+    @Override
+    public boolean removeBoard(String board) {
+        if (!getPlugin().getTopManager().boardExists(board)) {
+            getPlugin().getLogger().warning("Attempted to remove board that doesnt exist!");
+            return false;
+        }
+        try {
+            if (this instanceof SqliteMethod) {
+                ((SqliteMethod) this).newConnection();
+            }
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(String.format(
+                    this.formatStatement(DROP_TABLE),
+                    getTablePrefix() + board
+            ));
+            ps.executeUpdate();
+
+            ps.close();
+            this.close(conn);
+            getPlugin().getTopManager().fetchBoards();
+            getPlugin().getContextLoader().calculatePotentialContexts();
+            if (getPlugin().getTopManager().boardExists(board)) {
+                getPlugin().getLogger().warning("Attempted to remove a board, but it didnt get removed!");
+                return false;
+            }
+            return true;
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "An error occurred while trying to remove a board:", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void upsertPlayer(String board, OfflinePlayer player, double output, String prefix, String suffix, String displayName) {
+        Map<TimedType, Double> lastTotals = new HashMap<>();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            lastTotals.put(type, getLastTotal(board, player, type));
+        }
+        try (Connection conn = this.getConnection()) {
+            try {
+                PreparedStatement statement = conn.prepareStatement(String.format(
+                        this.formatStatement(INSERT_PLAYER),
+                        getTablePrefix() + board
+                ));
+                statement.setString(1, player.getUniqueId().toString());
+                statement.setDouble(2, output);
+                statement.setString(3, player.getName());
+                statement.setString(4, prefix);
+                statement.setString(5, suffix);
+                statement.setString(6, displayName);
+                int i = 6;
+                for (TimedType type : TimedType.values()) {
+                    if (type == TimedType.ALLTIME) continue;
+                    long lastReset = getPlugin().getTopManager().getLastReset(board, type) * 1000;
+                    if (getPlugin().isShuttingDown()) {
+                        this.close(conn);
+                    }
+                    statement.setDouble(++i, 0);
+                    statement.setDouble(++i, output);
+                    statement.setLong(++i, lastReset == 0 ? System.currentTimeMillis() : lastReset);
+                }
+
+                statement.executeUpdate();
+                statement.close();
+                this.close(conn);
+            } catch (SQLException e) {
+                try (PreparedStatement statement = conn.prepareStatement(String.format(
+                        this.formatStatement(UPDATE_PLAYER),
+                        getTablePrefix() + board
+                ))) {
+                    statement.setDouble(1, output);
+                    statement.setString(2, player.getName());
+                    statement.setString(3, prefix);
+                    statement.setString(4, suffix);
+                    statement.setString(5, displayName);
+                    Map<TimedType, Double> timedTypeValues = new HashMap<>();
+                    timedTypeValues.put(TimedType.ALLTIME, output);
+                    int i = 6;
+                    for (TimedType type : TimedType.values()) {
+                        if (type == TimedType.ALLTIME) continue;
+                        double timedOut = output - lastTotals.get(type);
+                        timedTypeValues.put(type, timedOut);
+                        statement.setDouble(i++, timedOut);
+                    }
+                    for (Map.Entry<TimedType, Double> timedTypeDoubleEntry : timedTypeValues.entrySet()) {
+                        TimedType type = timedTypeDoubleEntry.getKey();
+                        double timedOut = timedTypeDoubleEntry.getValue();
+
+                        StatEntry statEntry = getPlugin().getTopManager().getCachedStatEntry(player, board, type, false);
+                        if (statEntry != null && player.getUniqueId().equals(statEntry.getPlayerID())) {
+                            statEntry.changeScore(timedOut, prefix, suffix);
+                        }
+
+                        Integer position = getPlugin().getTopManager()
+                                .positionPlayerCache.getOrDefault(player.getUniqueId(), new HashMap<>())
+                                .get(new BoardType(board, type));
+                        if (position != null) {
+                            StatEntry stat = getPlugin().getTopManager().getCachedStat(position, board, type);
+                            if (stat != null && player.getUniqueId().equals(stat.getPlayerID())) {
+                                stat.changeScore(timedOut, prefix, suffix);
+                            }
+                        }
+                    }
+                    statement.setString(i, player.getUniqueId().toString());
+                    statement.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            if (getPlugin().isShuttingDown()) return;
+            getPlugin().getLogger().log(Level.WARNING, "Unable to update stat for player:", e);
+        }
+    }
+
+    @Override
+    public double getLastTotal(String board, OfflinePlayer player, TimedType type) {
+        double last = 0;
+        try {
+            Connection conn = this.getConnection();
+            try {
+                PreparedStatement ps = conn.prepareStatement(String.format(
+                        this.formatStatement(QUERY_LASTTOTAL),
+                        type.lowerName() + "_lasttotal",
+                        getTablePrefix() + board
+                ));
+
+                ps.setString(1, player.getUniqueId().toString());
+
+                ResultSet rs = ps.executeQuery();
+
+                if (this instanceof MysqlMethod || this instanceof H2Method) {
+                    rs.next();
+                }
+                last = rs.getDouble(1);
+                rs.close();
+                ps.close();
+                this.close(conn);
+            } catch (SQLException e) {
+                this.close(conn);
+                String m = e.getMessage();
+                if (m.contains("empty result set") || m.contains("ResultSet closed") || m.contains("[2000-"))
+                    return last;
+                getPlugin().getLogger().log(Level.WARNING, "Unable to get last total for " + player.getName() + " on " + type + " of " + board, e);
+            }
+        } catch (SQLException ignored) {
+        }
+
+        return last;
+    }
+
+    @Override
+    public long getLastReset(String board, TimedType type) {
+        long last = 0;
+        try {
+            Connection conn = this.getConnection();
+            try {
+                PreparedStatement ps = conn.prepareStatement(String.format(
+                        this.formatStatement(QUERY_LASTRESET),
+                        type.lowerName() + "_timestamp",
+                        getTablePrefix() + board
+                ));
+
+                ResultSet rs = ps.executeQuery();
+                if (this instanceof MysqlMethod || this instanceof H2Method) {
+                    rs.next();
+                }
+                last = rs.getLong(1);
+                ps.close();
+                this.close(conn);
+            } catch (SQLException e) {
+                this.close(conn);
+                String m = e.getMessage();
+                if (m.contains("empty result set") || m.contains("ResultSet closed") || m.contains("[2000-"))
+                    return last;
+                getPlugin().getLogger().log(Level.WARNING, "Unable to get last reset for " + type + " of " + board, e);
+            }
+        } catch (SQLException ignored) {
+        }
+
+        return last;
+    }
+
+    @Override
+    public void resetBoard(String board, TimedType type, long newTime) {
+        String t = type.lowerName();
+        try {
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(String.format(
+                    this.formatStatement(QUERY_IDVALUE),
+                    getTablePrefix() + board
+            ));
+
+            ResultSet rs = ps.executeQuery();
+            Map<String, Double> uuids = new HashMap<>();
+            while (rs.next()) {
+                uuids.put(rs.getString(1), rs.getDouble(2));
+            }
+            rs.close();
+            ps.close();
+            this.close(conn);
+            Partition<String> partition = Partition.ofSize(new ArrayList<>(uuids.keySet()), Math.max(uuids.size() / (int) Math.ceil(this.getMaxConnections() / 2D), 1));
+            Debug.info("Partition length: " + partition.size() + " uuids size: " + uuids.size() + " partition chunk size: " + partition.getChunkSize());
+            for (List<String> uuidPartition : partition) {
+                if (getPlugin().isShuttingDown()) {
+                    this.close(conn);
+                    return;
+                }
+                try {
+                    Connection con = this.getConnection();
+                    for (String idRaw : uuidPartition) {
+                        if (getPlugin().isShuttingDown()) {
+                            this.close(con);
+                            return;
+                        }
+                        PreparedStatement p = con.prepareStatement(String.format(
+                                this.formatStatement(UPDATE_RESET),
+                                getTablePrefix() + board,
+                                t + "_lasttotal",
+                                t + "_delta",
+                                t + "_timestamp"
+                        ));
+                        p.setDouble(1, uuids.get(idRaw));
+                        p.setDouble(2, 0);
+                        p.setLong(3, newTime);
+                        p.setString(4, idRaw);
+                        p.executeUpdate();
+                        p.close();
+                    }
+                    this.close(con);
+                } catch (SQLException e) {
+                    getPlugin().getLogger().log(Level.WARNING, "An error occurred while resetting " + type + " of " + board + ":", e);
+                }
+            }
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "An error occurred while resetting " + type + " of " + board + ":", e);
+        }
+    }
+
+    @Override
+    public void insertRows(String board, List<DbRow> rows) throws SQLException {
+        Connection conn = this.getConnection();
+        for (DbRow row : rows) {
+            PreparedStatement statement = conn.prepareStatement(String.format(
+                    this.formatStatement(INSERT_PLAYER),
+                    getTablePrefix() + board
+            ));
+            statement.setString(1, row.getId().toString());
+            statement.setDouble(2, row.getValue());
+            statement.setString(3, row.getNamecache());
+            statement.setString(4, row.getPrefixcache());
+            statement.setString(5, row.getSuffixcache());
+            statement.setString(6, row.getDisplaynamecache());
+            int i = 6;
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                if (getPlugin().isShuttingDown()) {
+                    this.close(conn);
+                }
+                statement.setDouble(++i, row.getDeltas().get(type));
+                statement.setDouble(++i, row.getLastTotals().get(type));
+                statement.setLong(++i, row.getTimestamps().get(type));
+            }
+
+            try {
+                statement.executeUpdate();
+            } catch (SQLException e) {
+                if (e.getMessage().contains("23505") || e.getMessage().contains("Duplicate entry") || e.getMessage().contains("PRIMARY KEY constraint failed")) {
+                    statement.close();
+                    continue;
+                }
+                throw e;
+            }
+            statement.close();
+        }
+        this.close(conn);
+    }
+
+    @Override
+    public List<DbRow> getRows(String board) throws SQLException {
+        Connection conn = this.getConnection();
+        PreparedStatement ps = conn.prepareStatement(String.format(
+                this.formatStatement(QUERY_ALL),
+                getTablePrefix() + board
+        ));
+        ResultSet resultSet = ps.executeQuery();
+
+        List<DbRow> out = new ArrayList<>();
+
+        while (resultSet.next()) {
+            out.add(new DbRow(resultSet));
+        }
+
+        ps.close();
+        resultSet.close();
+        this.close(conn);
+        return out;
+    }
+
+    @Override
+    public String getExtra(UUID id, String placeholder) {
+        try {
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(this.formatStatement(String.format(
+                    Objects.requireNonNull(QUERY_IDVALUE_EXTRA),
+                    getTablePrefix() + "extras"
+            )));
+
+            ps.setString(1, id.toString());
+            ps.setString(2, placeholder);
+
+            ResultSet rs = ps.executeQuery();
+
+            if (this instanceof MysqlMethod || this instanceof H2Method) {
+                rs.next();
+            }
+
+            String value = null;
+            try {
+                value = rs.getString(2);
+            } catch (SQLException e) {
+                if (
+                        !e.getMessage().contains("ResultSet closed") &&
+                                !e.getMessage().contains("empty result set") &&
+                                !e.getMessage().contains("[2000-")
+                ) {
+                    throw e;
+                }
+            }
+
+            rs.close();
+            ps.close();
+            this.close(conn);
+            return value;
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "An error occurred while fetching an extra:", e);
+            return StatEntry.AN_ERROR_OCCURRED;
+        }
+    }
+
+    @Override
+    public void upsertExtra(UUID id, String placeholder, String value) {
+        try {
+            Connection conn = this.getConnection();
+
+            PreparedStatement statement = conn.prepareStatement(String.format(
+                    this.formatStatement(UPDATE_PLAYER_EXTRA),
+                    getTablePrefix() + "extras"
+            ));
+            statement.setString(1, value);
+            statement.setString(2, id.toString());
+            statement.setString(3, placeholder);
+
+            int rowsChanged = statement.executeUpdate();
+            statement.close();
+            if (rowsChanged == 0) {
+                PreparedStatement insertStmt = conn.prepareStatement(String.format(
+                        this.formatStatement(INSERT_PLAYER_EXTRA),
+                        getTablePrefix() + "extras"
+                ));
+
+                insertStmt.setString(1, id.toString());
+                insertStmt.setString(2, placeholder);
+                insertStmt.setString(3, value);
+
+                insertStmt.executeUpdate();
+                insertStmt.close();
+            }
+            this.close(conn);
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.WARNING, "An error occurred while inserting an extra:", e);
+        }
+    }
+
+    @Override
+    public void createExtraTable() {
+        try {
+            Connection conn = this.getConnection();
+            PreparedStatement ps = conn.prepareStatement(this.formatStatement(String.format(
+                    Objects.requireNonNull(CREATE_EXTRA_TABLE.get(this.getName())),
+                    getTablePrefix() + "extras"
+            )));
+
+            ps.executeUpdate();
+
+            ps.close();
+            this.close(conn);
+        } catch (SQLException e) {
+            getPlugin().getLogger().log(Level.SEVERE, "Failed to create storage for Extras:", e);
+        }
+    }
+
+    private boolean isReverse(String board) {
+        return storageConfig.getStringList("reverse-sort").contains(board);
+    }
+
+    private String deltaBuilder() {
+        StringBuilder deltaBuilder = new StringBuilder();
+        for (TimedType t : TimedType.values()) {
+            if (t == TimedType.ALLTIME) continue;
+            deltaBuilder.append(getQuotationMark()).append(t.lowerName()).append("_delta").append(getQuotationMark()).append(",");
+        }
+        return deltaBuilder.deleteCharAt(deltaBuilder.length() - 1).toString();
+    }
+
+    private String columnBuilder(String t) {
+        String q = "'";
+        StringBuilder columns = new StringBuilder();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            columns
+                    .append(",\n").append(q).append(type.lowerName()).append("_delta").append(q).append(" ").append(t)
+                    .append(",\n").append(q).append(type.lowerName()).append("_lasttotal").append(q).append(" ").append(t)
+                    .append(",\n").append(q).append(type.lowerName()).append("_timestamp").append(q).append(" ").append(t);
+        }
+        return columns.toString();
+    }
+
+    private String qBuilder() {
+        StringBuilder addQs = new StringBuilder();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            addQs.append(", ?").append(", ?").append(", ?");
+        }
+        return addQs.toString();
+    }
+
+    private String tableBuilder() {
+        StringBuilder addTables = new StringBuilder();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            String name = type.lowerName();
+            addTables
+                    .append(", ").append(name).append("_delta")
+                    .append(", ").append(name).append("_lasttotal")
+                    .append(", ").append(name).append("_timestamp");
+        }
+        return addTables.toString();
+    }
+
+    private String updateBuilder() {
+        StringBuilder addUpdates = new StringBuilder();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            String name = type.lowerName();
+            addUpdates
+                    .append(", ").append(name).append("_delta").append("=?");
+        }
+        return addUpdates.toString();
+    }
+
+    private StatEntry processData(ResultSet r, String sortBy, int position, String board, TimedType type) throws SQLException {
+        String uuidRaw = null;
+        double value = -1;
+        String name = "-Unknown-";
+        String displayName = name;
+        String prefix = "";
+        String suffix = "";
+        if (this instanceof MysqlMethod || this instanceof H2Method) {
+            r.next();
+        }
+        try {
+            uuidRaw = r.getString(1);
+            name = r.getString(3);
+            prefix = r.getString(4);
+            suffix = r.getString(5);
+            displayName = r.getString(6);
+            value = r.getDouble(dataSortByIndexes.computeIfAbsent(sortBy,
+                    k -> {
+                        try {
+                            Debug.info("Calculating (process) column for " + sortBy);
+                            return r.findColumn(sortBy);
+                        } catch (SQLException e) {
+                            getPlugin().getLogger().log(Level.SEVERE, "Error while finding a column for " + sortBy, e);
+                            return -1;
+                        }
+                    }
+            ));
+        } catch (SQLException e) {
+            if (
+                    !e.getMessage().contains("ResultSet closed") &&
+                            !e.getMessage().contains("empty result set") &&
+                            !e.getMessage().contains("[2000-")
+            ) {
+                throw e;
+            }
+        }
+        if (name == null) name = "-Unknown";
+        r.close();
+        if (uuidRaw == null) {
+            return StatEntry.noData(getPlugin(), position, board, type);
+        } else {
+            return new StatEntry(position, board, prefix, name, displayName, UUID.fromString(uuidRaw), suffix, value, type);
+        }
+    }
+
+    protected ConfigFile getStorageConfig() {
+        return storageConfig;
+    }
+}

--- a/src/main/java/us/ajg0702/leaderboards/cache/methods/MongoDBMethod.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/methods/MongoDBMethod.java
@@ -1,0 +1,339 @@
+package us.ajg0702.leaderboards.cache.methods;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.Updates;
+import org.bson.Document;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.Nullable;
+import us.ajg0702.leaderboards.Debug;
+import us.ajg0702.leaderboards.LeaderboardPlugin;
+import us.ajg0702.leaderboards.boards.StatEntry;
+import us.ajg0702.leaderboards.boards.TimedType;
+import us.ajg0702.leaderboards.boards.keys.BoardType;
+import us.ajg0702.leaderboards.cache.Cache;
+import us.ajg0702.leaderboards.cache.CacheMethod;
+import us.ajg0702.leaderboards.cache.helpers.DbRow;
+import us.ajg0702.leaderboards.utils.Partition;
+import us.ajg0702.utils.common.ConfigFile;
+
+import java.sql.SQLException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+public class MongoDBMethod implements CacheMethod {
+    private final ConfigFile storageConfig;
+    private final String tablePrefix;
+    private MongoClient mongoClient;
+    private MongoDatabase mongoDatabase;
+    private LeaderboardPlugin plugin;
+
+    public MongoDBMethod(ConfigFile storageConfig) {
+        this.storageConfig = storageConfig;
+        this.tablePrefix = storageConfig.getString("table_prefix");
+    }
+
+    @Override
+    public void init(LeaderboardPlugin plugin, ConfigFile config, Cache cacheInstance) {
+        CodecRegistry codecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().conventions(Arrays.asList(Conventions.ANNOTATION_CONVENTION, Conventions.CLASS_AND_PROPERTY_CONVENTION,
+                        Conventions.OBJECT_ID_GENERATORS, Conventions.SET_PRIVATE_FIELDS_CONVENTION)).build()));
+        ConnectionString connString = new ConnectionString(storageConfig.getString("mongoConnectionString"));
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(connString)
+                .retryWrites(true)
+                .codecRegistry(codecRegistry)
+                .uuidRepresentation(UuidRepresentation.STANDARD)
+                .build();
+        this.mongoClient = MongoClients.create(settings);
+        this.mongoDatabase = this.mongoClient.getDatabase(this.storageConfig.getString("mongoDatabase"));
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void shutdown() {
+        mongoClient.close();
+    }
+
+    @Override
+    public String getName() {
+        return "mongodb";
+    }
+
+    @Override
+    public boolean requiresClose() {
+        return false;
+    }
+
+    @Override
+    public StatEntry getStatEntry(int position, String board, TimedType type) throws SQLException {
+        String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
+        StatEntry result = mongoDatabase.getCollection(tablePrefix + board, StatEntry.class).find()
+                .sort(isReverse(board) ? Sorts.descending(sortBy) : Sorts.ascending(sortBy))
+                .skip(position - 1).first();
+        return result == null ? StatEntry.boardNotFound(this.plugin, position, board, type) : result;
+    }
+
+    @Nullable
+    @Override
+    public StatEntry getStatEntry(OfflinePlayer player, String board, TimedType type) {
+        String sortBy = type == TimedType.ALLTIME ? "value" : type.lowerName() + "_delta";
+        StatEntry result = mongoDatabase.getCollection(tablePrefix + board, StatEntry.class)
+                .find()
+                .filter(Filters.eq("playerID", player.getUniqueId()))
+                .sort(isReverse(board) ? Sorts.descending(sortBy) : Sorts.ascending(sortBy))
+                .first();
+        return result == null ? StatEntry.boardNotFound(this.plugin, -1, board, type) : result;
+    }
+
+    @Override
+    public int getBoardSize(String board) {
+        return (int) mongoDatabase.getCollection(tablePrefix + board, StatEntry.class).countDocuments();
+    }
+
+    @Override
+    public double getLastTotal(String board, OfflinePlayer player, TimedType type) {
+        Document result = mongoDatabase.getCollection(tablePrefix + board)
+                .find()
+                .filter(Filters.eq("playerID", player.getUniqueId()))
+                .first();
+        if (result == null) {
+            return 0;
+        }
+        return result.get(type.lowerName() + "_delta", Double.class);
+    }
+
+    @Override
+    public long getLastReset(String board, TimedType type) {
+        Document result = mongoDatabase.getCollection(tablePrefix + board)
+                .find()
+                .first();
+        if (result == null) {
+            return 0;
+        }
+        return result.get(type.lowerName() + "_timestamp", Long.class);
+    }
+
+    @Override
+    public void resetBoard(String board, TimedType type, long newTime) {
+        Map<String, Double> uuids = new HashMap<>();
+        for (Document document : mongoDatabase.getCollection(tablePrefix + board).find()) {
+            uuids.put(document.getString("playerID"), document.getDouble(type.lowerName() + "_delta"));
+        }
+        Partition<String> partition = Partition.ofSize(new ArrayList<>(uuids.keySet()), Math.max(uuids.size(), 1));
+        Debug.info("Partition length: " + partition.size() + " uuids size: " + uuids.size() + " partition chunk size: " + partition.getChunkSize());
+        for (List<String> uuidPartition : partition) {
+            try {
+                for (String idRaw : uuidPartition) {
+                    if (this.plugin.isShuttingDown()) {
+                        return;
+                    }
+                    mongoDatabase.getCollection(tablePrefix + board)
+                            .updateOne(Filters.eq("playerID", idRaw),
+                                    Updates.combine(Updates.set(type.lowerName() + "_lasttotal", uuids.get(idRaw))
+                                            , Updates.set(type.lowerName() + "_delta", 0)
+                                            , Updates.set(type.lowerName() + "_timestamp", newTime)));
+                }
+            } catch (Exception e) {
+                this.plugin.getLogger().log(Level.WARNING, "An error occurred while resetting " + type + " of " + board + ":", e);
+            }
+        }
+    }
+
+    @Override
+    public void insertRows(String board, List<DbRow> rows) {
+        for (DbRow row : rows) {
+            Document document = new Document();
+            document.put("playerID", row.getId());
+            document.put("value", row.getValue());
+            document.put("namecache", row.getNamecache());
+            document.put("prefixcache", row.getPrefixcache());
+            document.put("suffixcache", row.getSuffixcache());
+            document.put("displaynamecache", row.getDisplaynamecache());
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                document.put(type.lowerName() + "_delta", row.getDeltas().get(type));
+                document.put(type.lowerName() + "_lasttotal", row.getLastTotals().get(type));
+                document.put(type.lowerName() + "_timestamp", row.getTimestamps().get(type));
+            }
+            mongoDatabase.getCollection(tablePrefix + board).insertOne(document);
+        }
+    }
+
+    @Override
+    public List<DbRow> getRows(String board) {
+        List<DbRow> rows = new ArrayList<>();
+        for (Document document : mongoDatabase.getCollection(tablePrefix + board).find()) {
+            Map<TimedType, Double> deltas = new HashMap<>();
+            Map<TimedType, Double> lastTotals = new HashMap<>();
+            Map<TimedType, Long> timestamps = new HashMap<>();
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                deltas.put(type, document.getDouble(type.lowerName() + "_delta"));
+                lastTotals.put(type, document.getDouble(type.lowerName() + "_lasttotal"));
+                timestamps.put(type, document.getLong(type.lowerName() + "_timestamp"));
+            }
+            rows.add(new DbRow(document.get("playerID", UUID.class), document.getDouble("value"), deltas, lastTotals, timestamps, document.getString("namecache"), document.getString("prefixcache"), document.getString("suffixcache"), document.getString("displaynamecache")));
+        }
+        return rows;
+    }
+
+    @Override
+    public boolean createBoard(String name) {
+        mongoDatabase.createCollection(tablePrefix + name);
+        return true;
+    }
+
+    @Override
+    public boolean removePlayer(String board, String playerName) {
+        return mongoDatabase.getCollection(tablePrefix + board).deleteOne(Filters.eq("namecache", playerName)).getDeletedCount() > 0;
+    }
+
+    @Override
+    public void upsertPlayer(String board, OfflinePlayer player, double output, String prefix, String suffix, String displayName) {
+        Map<TimedType, Double> lastTotals = new HashMap<>();
+        for (TimedType type : TimedType.values()) {
+            if (type == TimedType.ALLTIME) continue;
+            lastTotals.put(type, getLastTotal(board, player, type));
+        }
+        Document result = mongoDatabase.getCollection(tablePrefix + board)
+                .find()
+                .filter(Filters.eq("playerID", player.getUniqueId()))
+                .first();
+        if (result == null) {
+            Document document = new Document();
+            document.put("playerID", player.getUniqueId());
+            document.put("value", output);
+            document.put("namecache", player.getName());
+            document.put("prefixcache", prefix);
+            document.put("suffixcache", suffix);
+            document.put("displaynamecache", displayName);
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                document.put(type.lowerName() + "_delta", output - lastTotals.get(type));
+                document.put(type.lowerName() + "_lasttotal", output);
+                document.put(type.lowerName() + "_timestamp", System.currentTimeMillis());
+            }
+            mongoDatabase.getCollection(tablePrefix + board).insertOne(document);
+        } else {
+            Map<TimedType, Double> timedTypeValues = new HashMap<>();
+            timedTypeValues.put(TimedType.ALLTIME, output);
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                double timedOut = output - lastTotals.get(type);
+                timedTypeValues.put(type, timedOut);
+            }
+            for (Map.Entry<TimedType, Double> timedTypeDoubleEntry : timedTypeValues.entrySet()) {
+                TimedType type = timedTypeDoubleEntry.getKey();
+                double timedOut = timedTypeDoubleEntry.getValue();
+
+                StatEntry statEntry = this.plugin.getTopManager().getCachedStatEntry(player, board, type, false);
+                if (statEntry != null && player.getUniqueId().equals(statEntry.getPlayerID())) {
+                    statEntry.changeScore(timedOut, prefix, suffix);
+                }
+
+                Integer position = this.plugin.getTopManager()
+                        .positionPlayerCache.getOrDefault(player.getUniqueId(), new HashMap<>())
+                        .get(new BoardType(board, type));
+                if (position != null) {
+                    StatEntry stat = this.plugin.getTopManager().getCachedStat(position, board, type);
+                    if (stat != null && player.getUniqueId().equals(stat.getPlayerID())) {
+                        stat.changeScore(timedOut, prefix, suffix);
+                    }
+                }
+            }
+
+            Document document = new Document();
+            document.put("playerID", player.getUniqueId());
+            document.put("value", output);
+            document.put("namecache", player.getName());
+            document.put("prefixcache", prefix);
+            document.put("suffixcache", suffix);
+            document.put("displaynamecache", displayName);
+            for (TimedType type : TimedType.values()) {
+                if (type == TimedType.ALLTIME) continue;
+                document.put(type.lowerName() + "_delta", output - lastTotals.get(type));
+                document.put(type.lowerName() + "_lasttotal", output);
+                document.put(type.lowerName() + "_timestamp", System.currentTimeMillis());
+            }
+            mongoDatabase.getCollection(tablePrefix + board).replaceOne(Filters.eq("playerID", player.getUniqueId()), document);
+        }
+    }
+
+    @Override
+    public boolean removeBoard(String board) {
+        mongoDatabase.getCollection(tablePrefix + board).drop();
+        this.plugin.getTopManager().fetchBoards();
+        this.plugin.getContextLoader().calculatePotentialContexts();
+        if (this.plugin.getTopManager().boardExists(board)) {
+            this.plugin.getLogger().warning("Attempted to remove a board, but it didnt get removed!");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getDbTableList() {
+        List<String> tables = new ArrayList<>();
+        for (String name : mongoDatabase.listCollectionNames()) {
+            if (!name.startsWith(tablePrefix)) continue;
+            if (name.equals(tablePrefix + "extras")) continue;
+            tables.add(name);
+        }
+        return tables;
+    }
+
+    @Override
+    public List<String> getBoards() {
+        return getDbTableList().stream().map(s -> s.substring(tablePrefix.length())).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getExtra(UUID id, String placeholder) {
+        return Optional.ofNullable(mongoDatabase.getCollection(tablePrefix + "extras")
+                        .find(Filters.and(Filters.eq("playerID", id), Filters.eq("placeholder", placeholder)))
+                        .first())
+                .map(document -> document.getString("value"))
+                .orElse(null);
+    }
+
+    @Override
+    public void upsertExtra(UUID id, String placeholder, String value) {
+        Document result = mongoDatabase.getCollection(tablePrefix + "extras")
+                .find()
+                .filter(Filters.and(Filters.eq("playerID", id), Filters.eq("placeholder", placeholder)))
+                .first();
+        if (result == null) {
+            Document document = new Document();
+            document.put("playerID", id);
+            document.put("placeholder", placeholder);
+            document.put("value", value);
+            mongoDatabase.getCollection(tablePrefix + "extras").insertOne(document);
+        } else {
+            mongoDatabase.getCollection(tablePrefix + "extras").updateOne(Filters.and(Filters.eq("playerID", id), Filters.eq("placeholder", placeholder)),
+                    Updates.set("value", value));
+        }
+    }
+
+    @Override
+    public void createExtraTable() {
+        mongoDatabase.createCollection(tablePrefix + "extras");
+    }
+
+    private boolean isReverse(String board) {
+        return storageConfig.getStringList("reverse-sort").contains(board);
+    }
+}

--- a/src/main/java/us/ajg0702/leaderboards/cache/methods/SqliteMethod.java
+++ b/src/main/java/us/ajg0702/leaderboards/cache/methods/SqliteMethod.java
@@ -3,7 +3,7 @@ package us.ajg0702.leaderboards.cache.methods;
 import us.ajg0702.leaderboards.LeaderboardPlugin;
 import us.ajg0702.leaderboards.boards.TimedType;
 import us.ajg0702.leaderboards.cache.Cache;
-import us.ajg0702.leaderboards.cache.CacheMethod;
+import us.ajg0702.leaderboards.cache.SQLCacheMethod;
 import us.ajg0702.leaderboards.utils.UnClosableConnection;
 import us.ajg0702.utils.common.ConfigFile;
 
@@ -11,15 +11,20 @@ import java.io.File;
 import java.sql.*;
 import java.util.Locale;
 
-public class SqliteMethod implements CacheMethod {
+public class SqliteMethod extends SQLCacheMethod {
     private Connection conn;
     private LeaderboardPlugin plugin;
     private ConfigFile config;
     private Cache cacheInstance;
+
+    public SqliteMethod(ConfigFile storageConfig) {
+        super(storageConfig);
+    }
+
     @Override
     public Connection getConnection() {
         try {
-            if(conn.isClosed()) {
+            if (conn.isClosed()) {
                 plugin.getLogger().warning("Sqlite connection is dead, making a new one");
                 init(plugin, config, cacheInstance);
             }
@@ -116,7 +121,13 @@ public class SqliteMethod implements CacheMethod {
     }
 
     @Override
-    public void close(Connection connection) {}
+    public void close(Connection connection) {
+    }
+
+    @Override
+    protected LeaderboardPlugin getPlugin() {
+        return plugin;
+    }
 
     @Override
     public int getMaxConnections() {
@@ -135,6 +146,16 @@ public class SqliteMethod implements CacheMethod {
     @Override
     public String formatStatement(String s) {
         return s.replaceAll("'", "\"");
+    }
+
+    @Override
+    public String getQuotationMark() {
+        return "'";
+    }
+
+    @Override
+    public String getTablePrefix() {
+        return "";
     }
 
     @Override

--- a/src/main/resources/cache_storage.yml
+++ b/src/main/resources/cache_storage.yml
@@ -1,33 +1,35 @@
 # In this file, you can control where the cache is stored.
 
-# The method to use. h2 or mysql
-# If you select mysql, you will need to configure the settings below
+# The method to use. h2, sqlite, mysql or mongodb
+# If you select mysql or mongodb, you will need to configure the settings below
 #  Default: h2
 method: h2
 
 
 # You only need to touch these settings if you are using mysql
 ip: 127.0.0.1:3306
-username: mc
+username: username
 password: password
 database: mc
+# You only need to touch these settings if you are using mongodb
+mongoConnectionString: ""
+mongoDatabase: "ajLeaderboards"
 
 # Currently only used with mysql
 characterEncoding: "utf8"
 
 # Note that if you change this after already saving data in the db, ajleaderboards will not be able to see it.
 # In this case, you should either stick with the default or go through and rename the tables to use the new prefix
+# For mongodb, this is the collection name prefix
 table_prefix: ajlb_
 
 # These settings are for mysql only
-# If you dont know what these are for, I reccomend leaving them as default
+# If you dont know what these are for, I recommend leaving them as default
 minConnections: 1
 maxConnections: 20
 
 allowPublicKeyRetrieval: false
 useSSL: false
 
-
-
 # Dont touch me
-config-version: 5
+config-version: 6


### PR DESCRIPTION
In this PR, methods in Cache.java were abstracted into CacheMethod and implementations have been moved to SQLCacheMethod to make way for MongoDB support
MongoDB support has been tested on a 1.19 Paper Server
Data viewed in MongoDB Compass:
![image](https://github.com/ajgeiss0702/ajLeaderboards/assets/36107150/71db71fb-5f78-44dd-b059-c3cca57258a6)
