### PR TITLE
Optimized fetching thread pool

### DIFF
--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -43,9 +43,10 @@ public class TopManager {
         plugin = pl;
         CacheMethod method = plugin.getCache().getMethod();
         int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
+        int k = plugin.getAConfig().getInt("fetching-thread-pool-keep-alive");
         fetchService = new ThreadPoolExecutor(
                 t, t,
-                500, TimeUnit.MILLISECONDS,
+                k, TimeUnit.MILLISECONDS,
                 new ArrayBlockingQueue<>(1000000, true)
         );
         fetchService.allowCoreThreadTimeOut(true);

--- a/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
+++ b/src/main/java/us/ajg0702/leaderboards/boards/TopManager.java
@@ -42,15 +42,15 @@ public class TopManager {
     public TopManager(LeaderboardPlugin pl, List<String> initialBoards) {
         plugin = pl;
         CacheMethod method = plugin.getCache().getMethod();
-        int t = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
+        int tMin = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("min-fetching-threads");
+        int tMax = method instanceof MysqlMethod ? Math.max(10, method.getMaxConnections()) : plugin.getAConfig().getInt("max-fetching-threads");
         int k = plugin.getAConfig().getInt("fetching-thread-pool-keep-alive");
         fetchService = new ThreadPoolExecutor(
-                t, t,
+                tMin, tMax,
                 k, TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(1000000, true)
+                new ArrayBlockingQueue<>(1000000, true),
+                ThreadFactoryProxy.getDefaultThreadFactory("AJLBFETCH")
         );
-        fetchService.allowCoreThreadTimeOut(true);
-        fetchService.setThreadFactory(ThreadFactoryProxy.getDefaultThreadFactory("AJLBFETCH"));
         Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
             rolling.add(getQueuedTasks()+getActiveFetchers());
             if(rolling.size() > 50) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -149,21 +149,30 @@ particles: false
 # You really only need to use this if the dev asks for it.
 fetching-de-bug: false
 
+# What number of core threads should ajLeaderboards be allowed to use for fetching from the db?
+# These threads are always available and are created when the plugin is loaded.
+# This is ignored on mysql (and maxConnections is used for this instead)
+# I would __not__ recommend setting this above 10.
+# Requires a server restart to change
+#  Default: 4
+min-fetching-threads: 4
+
 # What maximum number of threads should ajLeaderboards be allowed to use for fetching from the db?
 # Most of the time, the number of threads used will be far less than this.
 # This is ignored on mysql (and maxConnections is used for this instead)
 # Lower this if you get the message "unable to create native thread: possibly out of memory or process/resource limits reached"
-# I would __not__ recommend setting this below 20.
+# I would __not__ recommend setting this below 16.
 # Requires a server restart to change
-#  Default: 70
-max-fetching-threads: 70
+#  Default: 16
+max-fetching-threads: 16
 
-# For how long (in milliseconds) should we keep a thread alive before killing it?
+# For how long (in milliseconds) should we keep a non-core thread alive before killing it?
 # This allows us to reuse threads instead of creating new ones every time we need to fetch something.
 # Creating new threads is expensive but keeping them alive for too long can consume resources.
+# I would __not__ recommend setting this below 5000.
 # Requires a server restart to change
-#  Default: 30000 (30 seconds)
-fetching-thread-pool-keep-alive: 30000
+#  Default: 60000 (60 seconds)
+fetching-thread-pool-keep-alive: 60000
 
 
 # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -158,6 +158,12 @@ fetching-de-bug: false
 #  Default: 70
 max-fetching-threads: 70
 
+# For how long (in milliseconds) should we keep a thread alive before killing it?
+# This allows us to reuse threads instead of creating new ones every time we need to fetch something.
+# Creating new threads is expensive but keeping them alive for too long can consume resources.
+# Requires a server restart to change
+#  Default: 30000 (30 seconds)
+fetching-thread-pool-keep-alive: 30000
 
 
 # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
While using ajLeaderboard on our server, I noticed excessive thread creation. Upon closer analysis, I found that a fixed 500 milliseconds may not be enough for the thread pool keepalive and is causing a waste of server performance. So I increased the thread keepalive to 30s and added the option to change it in the config.

The performance and stability of the plugin on the server has increased and we have not encountered any side effects, but I recommend to test more closely if necessary.