### PR TITLE
Update PaperMC Maven repository URL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
     maven { url = uri("https://repo.citizensnpcs.co/") }
     maven { url = uri("https://oss.sonatype.org/content/groups/public/") }
     maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
-    maven { url = uri("https://papermc.io/repo/repository/maven-public/") }
+    maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
 
     mavenLocal()
 }


### PR DESCRIPTION
`https://papermc.io/repo/repository/maven-public/` has been deprecated for removal and `https://repo.papermc.io/repository/maven-public/` should be used instead.